### PR TITLE
Primer: Expect no formatting changes in attrs, hypothesis and poetry

### DIFF
--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -10,7 +10,7 @@
     },
     "attrs": {
       "cli_arguments": [],
-      "expect_formatting_changes": true,
+      "expect_formatting_changes": false,
       "git_clone_url": "https://github.com/python-attrs/attrs.git",
       "long_checkout": false,
       "py_versions": ["all"]
@@ -47,7 +47,7 @@
     },
     "hypothesis": {
       "cli_arguments": [],
-      "expect_formatting_changes": true,
+      "expect_formatting_changes": false,
       "git_clone_url": "https://github.com/HypothesisWorks/hypothesis.git",
       "long_checkout": false,
       "py_versions": ["all"]
@@ -63,7 +63,7 @@
     },
     "poetry": {
       "cli_arguments": [],
-      "expect_formatting_changes": true,
+      "expect_formatting_changes": false,
       "git_clone_url": "https://github.com/python-poetry/poetry.git",
       "long_checkout": false,
       "py_versions": ["all"]


### PR DESCRIPTION
Primer on the CI is failing in https://github.com/psf/black/pull/1609 because it expects changes in attrs, hpyothesis and poetry.

Testing, there are changes with `--experimental-string-processing`, but not by default. So the config can be updated to expect no changes with those three. 